### PR TITLE
fix: handle Steam display_title edge cases

### DIFF
--- a/packages/frontend/src/lib/app-descriptions.ts
+++ b/packages/frontend/src/lib/app-descriptions.ts
@@ -572,7 +572,18 @@ registerTemplate(
 // Gaming platforms — displayTitle IS the game title
 registerTemplate(
   ["Steam"],
-  (t) => `正在Steam玩「${t}」喵~`
+  (t) => {
+    const tl = t.toLowerCase();
+    if (tl === "steam" || tl === "") return "正在浏览 Steam 喵~";
+    if (tl === "好友列表") return "正在与 Steam 好友聊天喵~";
+    // Hash-like strings (screenshot viewer etc) or friend names — hide details
+    if (/^[0-9a-f]{20,}/i.test(t)) return "正在浏览 Steam 喵~";
+    // Check if it looks like a game name (contains letters/CJK, not just a short nickname)
+    // Short titles without spaces/special chars are likely friend nicknames
+    // Game titles typically have spaces, English words, or are longer
+    if (t.length <= 20 && !/\s/.test(t) && !/[a-z]{3,}/i.test(t)) return "正在与 Steam 好友聊天喵~";
+    return `正在Steam玩「${t}」喵~`;
+  }
 );
 registerTemplate(
   ["Epic Games"],


### PR DESCRIPTION
## Summary

- Steam 的 `steamwebhelper.exe` 发送的 `display_title` 有多种情况，之前模板统一套用导致显示异常（如"正在Steam玩「Steam」喵~"）
- 现在按 display_title 内容区分处理：
  - `"Steam"` 或空 → 正在浏览 Steam 喵~
  - `"好友列表"` → 正在与 Steam 好友聊天喵~
  - hex hash（截图查看器）→ 正在浏览 Steam 喵~
  - 短文本无空格（好友昵称）→ 正在与 Steam 好友聊天喵~（不暴露好友名）
  - 其他（游戏名）→ 正在Steam玩「xxx」喵~

## Test plan

- [x] Steam 主界面 display_title="Steam" → 显示"正在浏览 Steam 喵~"
- [x] 好友列表窗口 display_title="好友列表" → 显示"正在与 Steam 好友聊天喵~"
- [x] 好友聊天窗口 display_title="小可想被带飞" → 显示"正在与 Steam 好友聊天喵~"
- [x] 截图查看 display_title="002D4225..." → 显示"正在浏览 Steam 喵~"
- [x] 游戏运行 display_title="Counter-Strike 2" → 显示"正在Steam玩「Counter-Strike 2」喵~"

🤖 Generated with [Claude Code](https://claude.com/claude-code)