### PR TITLE
feat: runtime site metadata injection via env vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,3 +5,9 @@ DEVICE_TOKEN_2=changeme_token2:my-phone:My Phone:android
 # HMAC secret for hashing window_title (used for dedup, prevents rainbow table attacks)
 # Generate with: openssl rand -hex 32
 HASH_SECRET=changeme_generate_a_random_secret
+
+# Optional site customization
+DISPLAY_NAME=Monika
+SITE_TITLE=Monika Now
+SITE_DESC=What is Monika doing right now?
+SITE_FAVICON=/favicon.ico

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,10 @@ services:
       - DEVICE_TOKEN_1=${DEVICE_TOKEN_1}
       - DEVICE_TOKEN_2=${DEVICE_TOKEN_2}
       - HASH_SECRET=${HASH_SECRET}
+      - DISPLAY_NAME=${DISPLAY_NAME}
+      - SITE_TITLE=${SITE_TITLE}
+      - SITE_DESC=${SITE_DESC}
+      - SITE_FAVICON=${SITE_FAVICON}
     volumes:
       - dashboard_data:/data
     networks:

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -8,6 +8,7 @@ import { handleHealth } from "./routes/health";
 import { handleHealthData, handleHealthDataQuery } from "./routes/health-data";
 import { handleHealthWebhook } from "./routes/health-webhook";
 import { handleConfig } from "./routes/config";
+import { injectSiteConfig } from "./services/site-config";
 
 // Start scheduled cleanup tasks (import triggers setInterval registration)
 import "./services/cleanup";
@@ -28,6 +29,17 @@ try {
   staticEnabled = true;
 } catch {
   console.warn(`[server] Static dir not found: ${STATIC_ROOT} — static files won't be served`);
+}
+
+async function serveStaticFile(realFile: string): Promise<Response> {
+  if (realFile.endsWith(".html")) {
+    const html = await Bun.file(realFile).text();
+    return new Response(injectSiteConfig(html), {
+      headers: { "Content-Type": "text/html; charset=utf-8" },
+    });
+  }
+
+  return new Response(Bun.file(realFile));
 }
 
 const server = Bun.serve({
@@ -102,12 +114,12 @@ const server = Bun.serve({
                 // Serve from the resolved real path
                 const file = Bun.file(realFile);
                 if (await file.exists()) {
-                  return new Response(file);
+                  return serveStaticFile(realFile);
                 }
                 // SPA fallback: file not found (or is a directory), serve index.html
                 const indexFile = Bun.file(`${REAL_STATIC_ROOT}/index.html`);
                 if (await indexFile.exists()) {
-                  return new Response(indexFile);
+                  return serveStaticFile(`${REAL_STATIC_ROOT}/index.html`);
                 }
                 response = Response.json({ error: "Not found" }, { status: 404 });
               }
@@ -115,7 +127,7 @@ const server = Bun.serve({
               // realpath fails if file doesn't exist — try SPA fallback
               const indexFile = Bun.file(`${REAL_STATIC_ROOT}/index.html`);
               if (await indexFile.exists()) {
-                return new Response(indexFile);
+                return serveStaticFile(`${REAL_STATIC_ROOT}/index.html`);
               }
               response = Response.json({ error: "Not found" }, { status: 404 });
             }

--- a/packages/backend/src/routes/config.ts
+++ b/packages/backend/src/routes/config.ts
@@ -1,10 +1,5 @@
-const displayName = process.env.DISPLAY_NAME || "Monika";
+import { getSiteConfig } from "../services/site-config";
 
 export function handleConfig(): Response {
-  return Response.json({
-    displayName,
-    siteTitle: process.env.SITE_TITLE || `${displayName} Now`,
-    siteDescription: process.env.SITE_DESC || `What is ${displayName} doing right now?`,
-    siteFavicon: process.env.SITE_FAVICON || "/favicon.ico",
-  });
+  return Response.json(getSiteConfig());
 }

--- a/packages/backend/src/services/site-config.ts
+++ b/packages/backend/src/services/site-config.ts
@@ -1,0 +1,92 @@
+export interface SiteConfig {
+  displayName: string;
+  siteTitle: string;
+  siteDescription: string;
+  siteFavicon: string;
+}
+
+export const DISPLAY_NAME_PLACEHOLDER = "__LIVE_DASHBOARD_DISPLAY_NAME__";
+export const SITE_TITLE_PLACEHOLDER = "__LIVE_DASHBOARD_SITE_TITLE__";
+export const SITE_DESCRIPTION_PLACEHOLDER = "__LIVE_DASHBOARD_SITE_DESCRIPTION__";
+export const SITE_FAVICON_PLACEHOLDER = "/__LIVE_DASHBOARD_SITE_FAVICON__";
+
+const DEFAULT_DISPLAY_NAME = "Monika";
+const DEFAULT_FAVICON = "/favicon.ico";
+const SCRIPT_TAG_PATTERN = /<script\b[^>]*>[\s\S]*?<\/script>/gi;
+
+function nonEmpty(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+function isValidFaviconUrl(url: string): boolean {
+  if (url.startsWith("/") && !url.startsWith("//")) return true;
+  try {
+    const parsed = new URL(url);
+    return parsed.protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
+export function getSiteConfig(): SiteConfig {
+  const displayName = nonEmpty(process.env.DISPLAY_NAME) ?? DEFAULT_DISPLAY_NAME;
+  const siteTitle = nonEmpty(process.env.SITE_TITLE) ?? `${displayName} Now`;
+  const siteDescription =
+    nonEmpty(process.env.SITE_DESC) ?? `What is ${displayName} doing right now?`;
+  const rawFavicon = nonEmpty(process.env.SITE_FAVICON) ?? DEFAULT_FAVICON;
+
+  return {
+    displayName,
+    siteTitle,
+    siteDescription,
+    siteFavicon: isValidFaviconUrl(rawFavicon) ? rawFavicon : DEFAULT_FAVICON,
+  };
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;");
+}
+
+function escapeJsString(value: string): string {
+  return JSON.stringify(value)
+    .slice(1, -1)
+    .replaceAll("<", "\\u003C")
+    .replaceAll(">", "\\u003E")
+    .replaceAll("&", "\\u0026");
+}
+
+function replacePlaceholders(
+  input: string,
+  config: SiteConfig,
+  escapeValue: (value: string) => string,
+): string {
+  return input
+    .replaceAll(DISPLAY_NAME_PLACEHOLDER, escapeValue(config.displayName))
+    .replaceAll(SITE_TITLE_PLACEHOLDER, escapeValue(config.siteTitle))
+    .replaceAll(SITE_DESCRIPTION_PLACEHOLDER, escapeValue(config.siteDescription))
+    .replaceAll(SITE_FAVICON_PLACEHOLDER, escapeValue(config.siteFavicon));
+}
+
+export function injectSiteConfig(html: string): string {
+  const config = getSiteConfig();
+  let result = "";
+  let lastIndex = 0;
+
+  for (const match of html.matchAll(SCRIPT_TAG_PATTERN)) {
+    const index = match.index ?? 0;
+    const script = match[0];
+
+    result += replacePlaceholders(html.slice(lastIndex, index), config, escapeHtml);
+    result += replacePlaceholders(script, config, escapeJsString);
+    lastIndex = index + script.length;
+  }
+
+  result += replacePlaceholders(html.slice(lastIndex), config, escapeHtml);
+  return result;
+}

--- a/packages/frontend/app/layout.tsx
+++ b/packages/frontend/app/layout.tsx
@@ -1,30 +1,21 @@
 import type { Metadata } from "next";
 import "./globals.css";
-import { fetchConfig, defaultConfig } from "@/lib/api";
+
+const DISPLAY_NAME_PLACEHOLDER = "__LIVE_DASHBOARD_DISPLAY_NAME__";
+const SITE_TITLE_PLACEHOLDER = "__LIVE_DASHBOARD_SITE_TITLE__";
+const SITE_DESCRIPTION_PLACEHOLDER = "__LIVE_DASHBOARD_SITE_DESCRIPTION__";
+const SITE_FAVICON_PLACEHOLDER = "/__LIVE_DASHBOARD_SITE_FAVICON__";
 
 export async function generateMetadata(): Promise<Metadata> {
-  try {
-    const config = await fetchConfig();
-    return {
-      title: config.siteTitle,
-      description: config.siteDescription,
-      icons: { icon: config.siteFavicon },
-      openGraph: {
-        title: config.siteTitle,
-        description: config.siteDescription,
-      },
-    };
-  } catch {
-    return {
-      title: defaultConfig.siteTitle,
-      description: defaultConfig.siteDescription,
-      icons: { icon: defaultConfig.siteFavicon },
-      openGraph: {
-        title: defaultConfig.siteTitle,
-        description: defaultConfig.siteDescription,
-      },
-    };
-  }
+  return {
+    title: SITE_TITLE_PLACEHOLDER,
+    description: SITE_DESCRIPTION_PLACEHOLDER,
+    icons: { icon: SITE_FAVICON_PLACEHOLDER },
+    openGraph: {
+      title: SITE_TITLE_PLACEHOLDER,
+      description: SITE_DESCRIPTION_PLACEHOLDER,
+    },
+  };
 }
 
 export default function RootLayout({
@@ -33,7 +24,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }) {
   return (
-    <html lang="zh-CN">
+    <html lang="zh-CN" data-display-name={DISPLAY_NAME_PLACEHOLDER}>
       <body className="min-h-screen bg-[var(--color-cream)] relative overflow-x-hidden">
         {/* Sakura petal layer */}
         <div className="sakura-container" aria-hidden="true">

--- a/packages/frontend/app/page.tsx
+++ b/packages/frontend/app/page.tsx
@@ -11,12 +11,14 @@ import DeviceCard from "@/components/DeviceCard";
 import DatePicker from "@/components/DatePicker";
 import Timeline from "@/components/Timeline";
 import HealthData from "@/components/HealthData";
+import SiteMetadataSync from "@/components/SiteMetadataSync";
 
 export default function Home() {
   const config = useConfigLoader();
 
   return (
     <ConfigContext.Provider value={config}>
+      <SiteMetadataSync />
       <HomeInner />
     </ConfigContext.Provider>
   );

--- a/packages/frontend/src/components/SiteMetadataSync.tsx
+++ b/packages/frontend/src/components/SiteMetadataSync.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { useEffect } from "react";
+import { useConfig } from "@/hooks/useConfig";
+
+function setMeta(selector: string, content: string) {
+  const element = document.head.querySelector<HTMLMetaElement>(selector);
+  if (element) {
+    element.setAttribute("content", content);
+    return;
+  }
+
+  const meta = document.createElement("meta");
+  if (selector.startsWith('meta[name="')) {
+    const name = selector.match(/^meta\[name="([^"]+)"\]$/)?.[1];
+    if (name) meta.setAttribute("name", name);
+  } else if (selector.startsWith('meta[property="')) {
+    const property = selector.match(/^meta\[property="([^"]+)"\]$/)?.[1];
+    if (property) meta.setAttribute("property", property);
+  }
+  meta.setAttribute("content", content);
+  document.head.appendChild(meta);
+}
+
+function setFavicon(href: string) {
+  const selectors = ['link[rel="icon"]', 'link[rel="shortcut icon"]'];
+  let updated = false;
+
+  for (const selector of selectors) {
+    const link = document.head.querySelector<HTMLLinkElement>(selector);
+    if (link) {
+      link.setAttribute("href", href);
+      updated = true;
+    }
+  }
+
+  if (!updated) {
+    const link = document.createElement("link");
+    link.setAttribute("rel", "icon");
+    link.setAttribute("href", href);
+    document.head.appendChild(link);
+  }
+}
+
+export default function SiteMetadataSync() {
+  const { siteTitle, siteDescription, siteFavicon } = useConfig();
+
+  useEffect(() => {
+    document.title = siteTitle;
+    setMeta('meta[name="description"]', siteDescription);
+    setMeta('meta[property="og:title"]', siteTitle);
+    setMeta('meta[property="og:description"]', siteDescription);
+    setMeta('meta[name="twitter:title"]', siteTitle);
+    setMeta('meta[name="twitter:description"]', siteDescription);
+    setFavicon(siteFavicon);
+  }, [siteTitle, siteDescription, siteFavicon]);
+
+  return null;
+}

--- a/packages/frontend/src/hooks/useConfig.ts
+++ b/packages/frontend/src/hooks/useConfig.ts
@@ -5,6 +5,45 @@ import { fetchConfig, defaultConfig } from "@/lib/api";
 import type { SiteConfig } from "@/lib/api";
 
 const ConfigContext = createContext<SiteConfig>(defaultConfig);
+const PLACEHOLDER_PREFIX = "__LIVE_DASHBOARD_";
+
+function readDocumentValue(value: string | null | undefined, fallback: string): string {
+  const trimmed = value?.trim();
+  if (!trimmed || trimmed.startsWith(PLACEHOLDER_PREFIX)) {
+    return fallback;
+  }
+  return trimmed;
+}
+
+function getInitialConfig(): SiteConfig {
+  if (typeof document === "undefined") {
+    return defaultConfig;
+  }
+
+  const displayName = readDocumentValue(
+    document.documentElement.getAttribute("data-display-name"),
+    defaultConfig.displayName,
+  );
+  const siteTitle = readDocumentValue(document.title, defaultConfig.siteTitle);
+  const siteDescription = readDocumentValue(
+    document.head.querySelector<HTMLMetaElement>('meta[name="description"]')?.content,
+    defaultConfig.siteDescription,
+  );
+  const siteFavicon = readDocumentValue(
+    document.head
+      .querySelector<HTMLLinkElement>('link[rel="icon"], link[rel="shortcut icon"]')
+      ?.getAttribute("href"),
+    defaultConfig.siteFavicon,
+  );
+
+  return {
+    ...defaultConfig,
+    displayName,
+    siteTitle,
+    siteDescription,
+    siteFavicon,
+  };
+}
 
 export function useConfig() {
   return useContext(ConfigContext);
@@ -13,13 +52,13 @@ export function useConfig() {
 export { ConfigContext };
 
 export function useConfigLoader(): SiteConfig {
-  const [config, setConfig] = useState<SiteConfig>(defaultConfig);
+  const [config, setConfig] = useState<SiteConfig>(() => getInitialConfig());
 
   useEffect(() => {
     const controller = new AbortController();
     fetchConfig(controller.signal)
-      .then((c) => {
-        if (!controller.signal.aborted) setConfig(c);
+      .then((nextConfig) => {
+        if (!controller.signal.aborted) setConfig(nextConfig);
       })
       .catch(() => {});
     return () => controller.abort();


### PR DESCRIPTION
## Summary

- Next.js export 在构建期固化 metadata，容器环境变量无法回写到已导出 HTML
- 前端改为输出占位符，后端在返回 .html 时做运行时替换（分上下文转义）
- `/api/config` 复用 `getSiteConfig()`，前后端不再漂移
- 客户端初始化从 DOM 读注入值，避免首屏闪回默认值

## Environment Variables

| 变量 | 说明 | 默认值 |
|------|------|--------|
| `DISPLAY_NAME` | 显示名 | `Monika` |
| `SITE_TITLE` | 页面标题 | `{DISPLAY_NAME} Now` |
| `SITE_DESC` | 页面描述 | `What is {DISPLAY_NAME} doing right now?` |
| `SITE_FAVICON` | favicon 路径 | `/favicon.ico` |

## Security

- SITE_FAVICON 仅允许根相对路径或 `https:` URL
- HTML 上下文转义 `& < > " '`，script 上下文 `JSON.stringify` + unicode escape

Closes #20

## Test plan

- [ ] 设置 `SITE_TITLE=Test` 重启后端，检查浏览器标签标题
- [ ] 描述含 `<` 和 `&` 时不破坏页面
- [ ] favicon 填非法 URL 时回退 `/favicon.ico`
- [ ] SPA 路由刷新（如 `/timeline`）也显示正确标题

🤖 Generated with [Claude Code](https://claude.com/claude-code)