### PR TITLE
fix: SSR displayName placeholder to prevent body flash

### DIFF
--- a/packages/frontend/src/hooks/useConfig.ts
+++ b/packages/frontend/src/hooks/useConfig.ts
@@ -6,6 +6,12 @@ import type { SiteConfig } from "@/lib/api";
 
 const ConfigContext = createContext<SiteConfig>(defaultConfig);
 const PLACEHOLDER_PREFIX = "__LIVE_DASHBOARD_";
+const serverRenderConfig: SiteConfig = {
+  displayName: "__LIVE_DASHBOARD_DISPLAY_NAME__",
+  siteTitle: "__LIVE_DASHBOARD_SITE_TITLE__",
+  siteDescription: "__LIVE_DASHBOARD_SITE_DESCRIPTION__",
+  siteFavicon: "/__LIVE_DASHBOARD_SITE_FAVICON__",
+};
 
 function readDocumentValue(value: string | null | undefined, fallback: string): string {
   const trimmed = value?.trim();
@@ -17,7 +23,7 @@ function readDocumentValue(value: string | null | undefined, fallback: string): 
 
 function getInitialConfig(): SiteConfig {
   if (typeof document === "undefined") {
-    return defaultConfig;
+    return serverRenderConfig;
   }
 
   const displayName = readDocumentValue(


### PR DESCRIPTION
## Summary
- `getInitialConfig()` returned `defaultConfig` during SSR, baking "Monika" into static HTML body
- Replace with `serverRenderConfig` containing placeholder strings for backend runtime injection
- Fixes the residual body flash issue from #20

## Verified
- Build output: Header/Footer contain `__LIVE_DASHBOARD_DISPLAY_NAME__` instead of "Monika"
- Runtime injection: `DISPLAY_NAME='Alice'` correctly replaces to "Alice Now"
- Client fallback: `readDocumentValue()` detects placeholder prefix and falls back correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)