### PR TITLE
fix(windows): add logging.shutdown() before hard exit

### DIFF
--- a/agents/windows/agent.py
+++ b/agents/windows/agent.py
@@ -781,6 +781,8 @@ class TrayAgent:
         shutdown_event.set()
         if self._icon:
             self._icon.stop()
+        logging.shutdown()
+        os._exit(0)
 
     @property
     def settings_requested(self) -> bool:


### PR DESCRIPTION
Follow-up to PR #27. Flush log handlers before os._exit(0) to prevent log loss.