### PR TITLE
chore(android): upgrade Health Connect to stable 1.1.0

### DIFF
--- a/agents/android-app/BUILD.md
+++ b/agents/android-app/BUILD.md
@@ -3,7 +3,7 @@
 ## 环境要求
 
 - **JDK**: 17+
-- **Android SDK**: compileSdk 34, minSdk 26
+- **Android SDK**: compileSdk 36, minSdk 26
 - **Gradle**: 使用项目自带的 `gradlew` wrapper
 - **IDE** (可选): Android Studio Hedgehog (2023.1.1) 或更新
 

--- a/agents/android-app/GUIDE.md
+++ b/agents/android-app/GUIDE.md
@@ -32,7 +32,7 @@
 
 ### 健康数据同步流程
 1. 用户在 HealthScreen 授权 Health Connect 权限
-2. 若设备开放 `FEATURE_READ_HEALTH_DATA_IN_BACKGROUND`（通常为 Android 15+），再额外授权后台读取权限
+2. 若设备开放 `FEATURE_READ_HEALTH_DATA_IN_BACKGROUND`（以设备与 Health Connect 的 feature 检测结果为准），再额外授权后台读取权限
 3. 选择数据类型 + 同步间隔
 4. `HealthSyncWorker` 通过 WorkManager 定时运行
 5. 从 Health Connect 读取 → POST 到 `/api/health-data`

--- a/agents/android-app/app/build.gradle.kts
+++ b/agents/android-app/app/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 
 android {
     namespace = "com.monika.dashboard"
-    compileSdk = 35
+    compileSdk = 36
 
     defaultConfig {
         applicationId = "com.monika.dashboard"
@@ -70,7 +70,7 @@ dependencies {
 
     // Health Connect background-read APIs are available here while staying
     // compatible with the current compileSdk / Android Gradle Plugin versions.
-    implementation("androidx.health.connect:connect-client:1.1.0-beta01")
+    implementation("androidx.health.connect:connect-client:1.1.0")
 
     // WorkManager
     implementation("androidx.work:work-runtime-ktx:2.9.0")

--- a/agents/android-app/app/src/main/java/com/monika/dashboard/ui/screens/HealthScreen.kt
+++ b/agents/android-app/app/src/main/java/com/monika/dashboard/ui/screens/HealthScreen.kt
@@ -198,11 +198,11 @@ fun HealthScreen(settings: SettingsStore) {
                     Text(
                         text = when {
                             backgroundFeatureAvailable && backgroundPermissionGranted ->
-                                "后台读取权限已授权；在支持该特性的设备（通常是 Android 15+）上会按设定间隔自动同步。"
+                                "后台读取权限已授权；是否支持后台自动同步以当前设备与 Health Connect 的 feature 检测结果为准。"
                             backgroundFeatureAvailable ->
                                 "此设备已开放后台读取能力，但还未授权后台读取权限。再授权一次即可启用后台自动同步。"
                             backgroundFeatureCheckFailed ->
-                                "暂时无法确认后台读取能力。如果你是 Android 15+ 设备，可尝试授权后台同步；Worker 执行时也会再次校验。"
+                                "暂时无法确认后台读取能力。是否可用以当前设备与 Health Connect 的 feature 检测结果为准；你仍可尝试授权后台同步，Worker 执行时也会再次校验。"
                             else ->
                                 "当前设备或 Health Connect 版本未开放后台读取。打开 APP 时仍会自动前台同步当天数据。"
                         },

--- a/agents/android-app/app/src/main/java/com/monika/dashboard/ui/screens/StatusScreen.kt
+++ b/agents/android-app/app/src/main/java/com/monika/dashboard/ui/screens/StatusScreen.kt
@@ -230,9 +230,9 @@ fun StatusScreen() {
                             !needsBgPerm -> "系统不需要额外后台读取权限，后台同步可直接工作"
                             bgEnabled -> "已授权后台读取健康数据，将按设定间隔自动同步"
                             bgFeatureCheckFailed ->
-                                "后台读取能力检测失败：${backgroundReadAvailability?.errorMessage ?: "未知错误"}\n如果你是 Android 15+ 设备，可先尝试授权；实际同步时也会再次校验。"
+                                "后台读取能力检测失败：${backgroundReadAvailability?.errorMessage ?: "未知错误"}\n是否可用以当前设备与 Health Connect 的 feature 检测结果为准；你仍可先尝试授权，实际同步时也会再次校验。"
                             bgUnavailable ->
-                                "当前设备或 Health Connect 版本未开放后台读取。通常需要 Android 15+ 或支持该特性的系统模块。\n打开 APP 时会自动同步当天数据"
+                                "当前设备或 Health Connect 版本未开放后台读取。是否支持以当前设备与 Health Connect 的 feature 检测结果为准。\n打开 APP 时会自动同步当天数据"
                             else ->
                                 "后台读取权限未授权，请在 Health Connect 中开启\n当前打开 APP 时会自动同步当天数据"
                         },

--- a/agents/android-app/build.gradle.kts
+++ b/agents/android-app/build.gradle.kts
@@ -1,4 +1,4 @@
 plugins {
-    id("com.android.application") version "8.6.1" apply false
+    id("com.android.application") version "8.9.1" apply false
     id("org.jetbrains.kotlin.android") version "1.9.22" apply false
 }

--- a/agents/android-app/gradle/wrapper/gradle-wrapper.properties
+++ b/agents/android-app/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=544c35d6bd849ae8a5ed0bcea39ba677dc40f49df7d1835561582da2009b961d
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionSha256Sum=f397b287023acdba1e9f6fc5ea72d22dd63669d59ed4a289a29b1a76eee151c6
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
## Summary
- Upgrade `connect-client` from 1.1.0-beta01 to stable 1.1.0
- Minimum toolchain bump: compileSdk 36, AGP 8.9.1, Gradle 8.11.1
- targetSdk stays at 35 (no runtime behavior change)
- Replace "Android 15+" wording with feature-detection-based phrasing

## Test plan
- [x] `./gradlew app:assembleDebug` — BUILD SUCCESSFUL
- [ ] Verify Health Connect permissions flow on device

🤖 Generated with [Claude Code](https://claude.com/claude-code)